### PR TITLE
Add common generics to pylint good-names list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,8 @@ warn_unused_ignores = true
 [tool.pylint.BASIC]
 good-names = [
   "_",
+  "_P",
+  "_R",
   "ex",
   "fp",
   "i",
@@ -114,6 +116,8 @@ good-names = [
   "k",
   "on",
   "Run",
+  "P",
+  "R",
   "T",
 ]
 


### PR DESCRIPTION
# Proposed Changes

Add common generic parameter names `_P`, `_R`, `P`, `R` to pylint good-names list

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
