### PR TITLE
Disable ruff FBT001 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ warn_unused_ignores = true
     "D100",  # Missing docstring in public module
     "D103",  # Missing docstring in public function
     "D104",  # Missing docstring in public package
+    "FBT001", # boolean-type-hint-positional-argument
     "N802",  # Function name {name} should be lowercase
     "N816",  # Variable {name} in global scope should not be mixedCase
     "PLR0913", # Too many arguments in function definition


### PR DESCRIPTION
# Proposed Changes

Disable ruff FBT001 in tests, primarily to allow for fixtures typed as `bool`

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
