### PR TITLE
Require min version of 1.9.5

### DIFF
--- a/go2rtc_client/rest.py
+++ b/go2rtc_client/rest.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 _API_PREFIX = "/api"
-_MIN_VERSION_SUPPORTED: Final = AwesomeVersion("1.9.4")
+_MIN_VERSION_SUPPORTED: Final = AwesomeVersion("1.9.5")
 _MIN_VERSION_UNSUPPORTED: Final = AwesomeVersion("2.0.0")
 
 

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -98,9 +98,9 @@ async def test_streams_add(
     ("server_version", "expected_result"),
     [
         ("0.0.0", False),
-        ("1.9.3", False),
-        ("1.9.4", True),
+        ("1.9.4", False),
         ("1.9.5", True),
+        ("1.9.6", True),
         ("2.0.0", False),
         ("BLAH", False),
     ],


### PR DESCRIPTION
# Proposed Changes

Set the min supported version to `1.9.5` as the following PRs need functionality first added in `1.9.5`:
- https://github.com/home-assistant-libs/python-go2rtc-client/pull/4
- https://github.com/home-assistant-libs/python-go2rtc-client/pull/3
