### PR TITLE
Make Go2RtcRestClient.validate_server_version a classmethod

### DIFF
--- a/go2rtc_client/rest.py
+++ b/go2rtc_client/rest.py
@@ -144,10 +144,15 @@ class Go2RtcRestClient:
         self.streams: Final = _StreamClient(self._client)
         self.webrtc: Final = _WebRTCClient(self._client)
 
+    @classmethod
     @handle_error
-    async def validate_server_version(self) -> None:
+    async def validate_server_version(
+        cls, websession: ClientSession, server_url: str
+    ) -> bool:
         """Validate the server version is compatible."""
-        application_info = await self.application.get_info()
+        client = _BaseClient(websession, server_url)
+        application = _ApplicationClient(client)
+        application_info = await application.get_info()
         try:
             version_supported = (
                 _MIN_VERSION_SUPPORTED

--- a/go2rtc_client/rest.py
+++ b/go2rtc_client/rest.py
@@ -148,7 +148,7 @@ class Go2RtcRestClient:
     @handle_error
     async def validate_server_version(
         cls, websession: ClientSession, server_url: str
-    ) -> bool:
+    ) -> None:
         """Validate the server version is compatible."""
         client = _BaseClient(websession, server_url)
         application = _ApplicationClient(client)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -11,8 +11,8 @@ from aiohttp.hdrs import METH_PUT
 from awesomeversion import AwesomeVersion
 import pytest
 
-from go2rtc_client.exceptions import Go2RtcVersionError
 from go2rtc_client import Go2RtcRestClient
+from go2rtc_client.exceptions import Go2RtcVersionError
 from go2rtc_client.models import WebRTCSdpOffer
 from go2rtc_client.rest import _ApplicationClient, _StreamClient, _WebRTCClient
 from tests import load_fixture


### PR DESCRIPTION
# Proposed Changes

Make `Go2RtcRestClient.validate_server_version` a classmethod; the method will be called before a client is created to validate the server

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
