### PR TITLE
Make rest client time out after 10s

### DIFF
--- a/go2rtc_client/rest.py
+++ b/go2rtc_client/rest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Final, Literal
 
-from aiohttp import ClientError, ClientResponse, ClientSession
+from aiohttp import ClientError, ClientResponse, ClientSession, ClientTimeout
 from aiohttp.client import _RequestOptions
 from awesomeversion import AwesomeVersion, AwesomeVersionException
 from mashumaro.codecs.basic import BasicDecoder
@@ -46,7 +46,7 @@ class _BaseClient:
         _LOGGER.debug("request[%s] %s", method, url)
         if isinstance(data, DataClassDictMixin):
             data = data.to_dict()
-        kwargs = _RequestOptions({})
+        kwargs = _RequestOptions(timeout=ClientTimeout(total=10))
         if params:
             kwargs["params"] = params
         if data:

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -6,6 +6,7 @@ from contextlib import AbstractContextManager, nullcontext as does_not_raise
 import json
 from typing import TYPE_CHECKING, Any
 
+from aiohttp import ClientTimeout
 from aiohttp.hdrs import METH_PUT
 from awesomeversion import AwesomeVersion
 import pytest
@@ -93,7 +94,9 @@ async def test_streams_add(
         "camera.12mp_fluent", "rtsp://test:test@192.168.10.105:554/Preview_06_sub"
     )
 
-    responses.assert_called_once_with(url, method=METH_PUT, params=params)
+    responses.assert_called_once_with(
+        url, method=METH_PUT, params=params, timeout=ClientTimeout(total=10)
+    )
 
 
 VERSION_ERR = "server version '{}' not >= 1.9.5 and < 2.0.0"


### PR DESCRIPTION
# Proposed Changes

Make rest client time out after 10s, waiting longer indicates the server is not working

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
