### PR TITLE
Fix producers can be null

### DIFF
--- a/go2rtc_client/models.py
+++ b/go2rtc_client/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from awesomeversion import AwesomeVersion
 from mashumaro import field_options
@@ -43,6 +43,15 @@ class Stream:
     """Stream model."""
 
     producers: list[Producer]
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[Any, Any]) -> dict[Any, Any]:
+        """Pre deserialize."""
+        # Ensure producers is always a list
+        if "producers" in d and d["producers"] is None:
+            d["producers"] = []
+
+        return d
 
 
 @dataclass

--- a/tests/__snapshots__/test_rest.ambr
+++ b/tests/__snapshots__/test_rest.ambr
@@ -24,6 +24,14 @@
     }),
   })
 # ---
+# name: test_streams_get[without producers]
+  dict({
+    'camera.12mp_fluent': dict({
+      'producers': list([
+      ]),
+    }),
+  })
+# ---
 # name: test_webrtc_offer
   dict({
     'sdp': 'v=0...',

--- a/tests/fixtures/streams_without_producers.json
+++ b/tests/fixtures/streams_without_producers.json
@@ -1,0 +1,31 @@
+{
+  "camera.12mp_fluent": {
+    "producers": null,
+    "consumers": [
+      {
+        "id": 1,
+        "format_name": "webrtc/json",
+        "protocol": "http+udp",
+        "remote_addr": "192.168.10.20:44460 prflx",
+        "user_agent": "HomeAssistant/2024.10.0.dev0 aiohttp/3.10.5 Python/3.12",
+        "medias": [
+          "video, sendonly, VP8, VP9, H264",
+          "audio, sendonly, OPUS/48000/2, G722/8000, PCMU/8000, PCMA/8000, L16, PCML"
+        ],
+        "senders": [
+          {
+            "id": 4,
+            "codec": {
+              "codec_name": "h264",
+              "codec_type": "video"
+            },
+            "parent": 3,
+            "bytes": 1714455,
+            "packets": 1255
+          }
+        ],
+        "bytes_send": 1733057
+      }
+    ]
+  }
+}

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -44,13 +44,11 @@ async def test_application_info(
 
 @pytest.mark.parametrize(
     "filename",
-    [
-        "streams_one.json",
-        "streams_none.json",
-    ],
+    ["streams_one.json", "streams_none.json", "streams_without_producers.json"],
     ids=[
         "one stream",
         "empty",
+        "without producers",
     ],
 )
 async def test_streams_get(


### PR DESCRIPTION
# Proposed Changes

/api/streams may have stream with null producers. If stream has only name with empty source list. This is useful for input stream.

go2rtc config:
```yaml
streams:
  camera1:
```

Credits to @AlexxIT