### PR TITLE
Don't add automatically ffmpeg audio transcoding

### DIFF
--- a/go2rtc_client/rest.py
+++ b/go2rtc_client/rest.py
@@ -119,19 +119,19 @@ class _StreamClient:
         self._client = client
 
     @handle_error
-    async def list(self) -> dict[str, Stream]:
-        """List streams registered with the server."""
-        resp = await self._client.request("GET", self.PATH)
-        return _GET_STREAMS_DECODER.decode(await resp.json())
-
-    @handle_error
-    async def add(self, name: str, source: str) -> None:
+    async def add(self, name: str, sources: str | list[str]) -> None:
         """Add a stream to the server."""
         await self._client.request(
             "PUT",
             self.PATH,
-            params={"name": name, "src": [source, f"ffmpeg:{name}#audio=opus"]},
+            params={"name": name, "src": sources},
         )
+
+    @handle_error
+    async def list(self) -> dict[str, Stream]:
+        """List streams registered with the server."""
+        resp = await self._client.request("GET", self.PATH)
+        return _GET_STREAMS_DECODER.decode(await resp.json())
 
 
 class Go2RtcRestClient:

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -73,23 +73,28 @@ async def test_streams_add(
 ) -> None:
     """Test add stream."""
     url = f"{URL}{_StreamClient.PATH}"
+    camera = "camera.12mp_fluent"
     params = {
-        "name": "camera.12mp_fluent",
+        "name": camera,
         "src": [
             "rtsp://test:test@192.168.10.105:554/Preview_06_sub",
-            "ffmpeg:camera.12mp_fluent#audio=opus",
+            f"ffmpeg:{camera}#audio=opus",
         ],
     }
     responses.put(
         url
-        + "?name=camera.12mp_fluent"
-        + "&src=ffmpeg%253Acamera.12mp_fluent%2523audio%253Dopus"
+        + f"?name={camera}"
+        + f"&src=ffmpeg%253A{camera}%2523audio%253Dopus"
         + "&src=rtsp%253A%252F%252Ftest%253Atest%2540192.168.10.105%253A554%252F"
         + "Preview_06_sub",
         status=200,
     )
     await rest_client.streams.add(
-        "camera.12mp_fluent", "rtsp://test:test@192.168.10.105:554/Preview_06_sub"
+        camera,
+        [
+            "rtsp://test:test@192.168.10.105:554/Preview_06_sub",
+            f"ffmpeg:{camera}#audio=opus",
+        ],
     )
 
     responses.assert_called_once_with(

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -67,7 +67,7 @@ async def test_streams_get(
     assert resp == snapshot
 
 
-async def test_streams_add(
+async def test_streams_add_list(
     responses: aioresponses,
     rest_client: Go2RtcRestClient,
 ) -> None:
@@ -95,6 +95,34 @@ async def test_streams_add(
             "rtsp://test:test@192.168.10.105:554/Preview_06_sub",
             f"ffmpeg:{camera}#audio=opus",
         ],
+    )
+
+    responses.assert_called_once_with(
+        url, method=METH_PUT, params=params, timeout=ClientTimeout(total=10)
+    )
+
+
+async def test_streams_add_str(
+    responses: aioresponses,
+    rest_client: Go2RtcRestClient,
+) -> None:
+    """Test add stream."""
+    url = f"{URL}{_StreamClient.PATH}"
+    camera = "camera.12mp_fluent"
+    params = {
+        "name": camera,
+        "src": "rtsp://test:test@192.168.10.105:554/Preview_06_sub",
+    }
+    responses.put(
+        url
+        + f"?name={camera}"
+        + "&src=rtsp%253A%252F%252Ftest%253Atest%2540192.168.10.105%253A554%252F"
+        + "Preview_06_sub",
+        status=200,
+    )
+    await rest_client.streams.add(
+        camera,
+        "rtsp://test:test@192.168.10.105:554/Preview_06_sub",
     )
 
     responses.assert_called_once_with(


### PR DESCRIPTION
# Proposed Changes

Until now, we automatically added `f"ffmpeg:{name}#audio=opus"` as a second stream to have WebRTC audio support.
But there are cameras which don't have audio at all, and therefore the caller should decide, which sources should be added.
