### PR TITLE
Remove upper constraint for awesomeversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">=3.12.0"
 dependencies = [
     "aiohttp~=3.10",
-    "awesomeversion~=25.5",
+    "awesomeversion>=24.6",
     "mashumaro~=3.13",
     "orjson~=3.10",
     "webrtc-models~=0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -304,7 +304,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = "~=3.10" },
-    { name = "awesomeversion", specifier = "~=25.5" },
+    { name = "awesomeversion", specifier = ">=24.6" },
     { name = "mashumaro", specifier = "~=3.13" },
     { name = "orjson", specifier = "~=3.10" },
     { name = "webrtc-models", specifier = "~=0.1" },


### PR DESCRIPTION
# Proposed Changes

`awesomeversion` uses `CalVer`. The constraint is currently blocking the update to `25.5.0` in Home Assistant.
A new release and bump in Home Assistant would be great.

## Related Issues
Ref https://github.com/home-assistant/core/pull/146032