### PR TITLE
Fix streams list failing when a stream has WHIP/WebRTC push producers

### DIFF
--- a/go2rtc_client/models.py
+++ b/go2rtc_client/models.py
@@ -58,7 +58,7 @@ class Stream:
 class Producer:
     """Producer model."""
 
-    url: str
+    url: str | None = None
 
 
 @dataclass

--- a/tests/__snapshots__/test_rest.ambr
+++ b/tests/__snapshots__/test_rest.ambr
@@ -45,6 +45,17 @@
     }),
   })
 # ---
+# name: test_streams_get[whip producer without url]
+  dict({
+    'camera.kiosk_tablet': dict({
+      'producers': list([
+        dict({
+          'url': None,
+        }),
+      ]),
+    }),
+  })
+# ---
 # name: test_streams_get[without producers]
   dict({
     'camera.12mp_fluent': dict({

--- a/tests/fixtures/streams_whip_producer.json
+++ b/tests/fixtures/streams_whip_producer.json
@@ -1,0 +1,34 @@
+{
+  "camera.kiosk_tablet": {
+    "producers": [
+      {
+        "id": 4439,
+        "format_name": "webrtc",
+        "protocol": "http+udp",
+        "remote_addr": "192.168.10.212:59793 host",
+        "user_agent": "Mozilla/5.0 (Linux; Android 8.1.0; Lenovo StarView Build/OPM7.181205.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/138.0.7204.181 Safari/537.36",
+        "medias": [
+          "video, recvonly, H264",
+          "video, sendonly, VP8, VP9, H264"
+        ],
+        "receivers": [
+          {
+            "id": 4440,
+            "codec": {
+              "codec_name": "h264",
+              "codec_type": "video"
+            },
+            "childs": [
+              4447,
+              4456
+            ],
+            "bytes": 37630084,
+            "packets": 34687
+          }
+        ],
+        "bytes_recv": 38330115
+      }
+    ],
+    "consumers": []
+  }
+}

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -50,11 +50,17 @@ async def test_application_info(
 
 @pytest.mark.parametrize(
     "filename",
-    ["streams_one.json", "streams_none.json", "streams_without_producers.json"],
+    [
+        "streams_one.json",
+        "streams_none.json",
+        "streams_without_producers.json",
+        "streams_whip_producer.json",
+    ],
     ids=[
         "one stream",
         "empty",
         "without producers",
+        "whip producer without url",
     ],
 )
 async def test_streams_get(


### PR DESCRIPTION
Fixes #344.

Producers created by **pushing** into go2rtc (WHIP ingest / WebRTC push) have no `"url"` key in the `/api/streams` payload — there is no source URL, the media was pushed. The strict decoder required `Producer.url`, so a single pushed stream anywhere made the **entire** streams list undecodable, which in Home Assistant breaks every camera still (`async_get_image`) and WebRTC offer in the instance while a publisher is connected.

- Make `Producer.url` optional, matching what go2rtc actually reports
- Add a fixture with a real WHIP producer payload (captured from go2rtc v1.9.14) and a `test_streams_get` case for it

Same category as #21, which handled `producers` itself being null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
