### PR TITLE
Fix uv warning for dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ version = "0.0.0"
 "Source Code" = "https://github.com/home-assistant-libs/python-go2rtc-client"
 "Bug Reports" = "https://github.com/home-assistant-libs/python-go2rtc-client/issues"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "aioresponses>=0.7.6",
     "covdefaults>=2.3.0",
     "mypy==2.3.0",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

- Update dev deps group setting in pyproject.toml, to avoid deprecation warning in uv.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
