### PR TITLE
Switch test suite from aioresponses to aiointercept

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.0.0"
 
 [dependency-groups]
 dev = [
-    "aioresponses>=0.7.6",
+    "aiointercept>=0.1.9",
     "covdefaults>=2.3.0",
     "mypy==2.3.0",
     "pre-commit==4.6.1",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,25 @@
 
 from pathlib import Path
 
+from aiohttp import ClientTimeout
+
+type RequestTimeouts = dict[tuple[str, str], list[ClientTimeout | None]]
+
+
+def assert_request_timeout(
+    request_timeouts: RequestTimeouts,
+    method: str,
+    url: str,
+    *,
+    timeout: ClientTimeout | None,
+) -> None:
+    """Assert the client side timeout set for the given request."""
+    key = (method, url)
+    assert key in request_timeouts, f"no request captured for {key}"
+    timeouts = request_timeouts[key]
+    assert len(timeouts) == 1, f"expected one request for {key}, got {len(timeouts)}"
+    assert timeouts[0] == timeout
+
 
 def load_fixture(filename: str) -> Path:
     """Load a fixture."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,16 @@
 """Asynchronous Python client for go2rtc."""
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator
+from typing import Any
 
-import aiohttp
-from aioresponses import aioresponses
+from aiohttp import ClientSession
+from aiointercept import aiointercept
 import pytest
 from syrupy import SnapshotAssertion
 
 from go2rtc_client import Go2RtcRestClient
 
-from . import URL
+from . import URL, RequestTimeouts
 from .syrupy import Go2RtcSnapshotExtension
 
 
@@ -23,7 +24,7 @@ def snapshot_assertion(snapshot: SnapshotAssertion) -> SnapshotAssertion:
 async def rest_client() -> AsyncGenerator[Go2RtcRestClient, None]:
     """Return a go2rtc rest client."""
     async with (
-        aiohttp.ClientSession() as session,
+        ClientSession() as session,
     ):
         client_ = Go2RtcRestClient(
             session,
@@ -33,7 +34,28 @@ async def rest_client() -> AsyncGenerator[Go2RtcRestClient, None]:
 
 
 @pytest.fixture(name="responses")
-def aioresponses_fixture() -> Generator[aioresponses, None, None]:
-    """Return aioresponses fixture."""
-    with aioresponses() as mocked_responses:
+async def aiointercept_fixture() -> AsyncGenerator[aiointercept, None]:
+    """Return aiointercept fixture."""
+    async with aiointercept(mock_external_urls=True) as mocked_responses:
         yield mocked_responses
+
+
+@pytest.fixture(name="request_timeouts")
+def request_timeouts_fixture(monkeypatch: pytest.MonkeyPatch) -> RequestTimeouts:
+    """Capture the client side timeout passed to each request.
+
+    aiointercept routes requests through a real test server, so the client side
+    timeout is not visible in the captured request. Record it here instead.
+    """
+    timeouts: RequestTimeouts = {}
+    original = ClientSession.request
+
+    def _capture(
+        self: ClientSession, method: str, str_or_url: Any, **kwargs: Any
+    ) -> Any:
+        key = (method, str(str_or_url))
+        timeouts.setdefault(key, []).append(kwargs.get("timeout"))
+        return original(self, method, str_or_url, **kwargs)
+
+    monkeypatch.setattr(ClientSession, "request", _capture)
+    return timeouts

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -10,6 +10,7 @@ from aiohttp import ClientTimeout
 from aiohttp.hdrs import METH_PUT
 from awesomeversion import AwesomeVersion
 import pytest
+import yarl
 
 from go2rtc_client.exceptions import Go2RtcVersionError
 from go2rtc_client.models import WebRTCSdpOffer
@@ -22,17 +23,23 @@ from go2rtc_client.rest import (
     _WebRTCClient,
 )
 
-from . import URL, load_fixture_bytes, load_fixture_str
+from . import (
+    URL,
+    RequestTimeouts,
+    assert_request_timeout,
+    load_fixture_bytes,
+    load_fixture_str,
+)
 
 if TYPE_CHECKING:
-    from aioresponses import aioresponses
+    from aiointercept import aiointercept
     from syrupy import SnapshotAssertion
 
     from go2rtc_client import Go2RtcRestClient
 
 
 async def test_application_info(
-    responses: aioresponses,
+    responses: aiointercept,
     rest_client: Go2RtcRestClient,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -58,7 +65,7 @@ async def test_application_info(
     ],
 )
 async def test_streams_get(
-    responses: aioresponses,
+    responses: aiointercept,
     rest_client: Go2RtcRestClient,
     snapshot: SnapshotAssertion,
     filename: str,
@@ -74,27 +81,25 @@ async def test_streams_get(
 
 
 async def test_streams_add_list(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     rest_client: Go2RtcRestClient,
 ) -> None:
     """Test add stream."""
     url = f"{URL}{_StreamClient.PATH}"
     camera = "camera.12mp_fluent"
-    params = {
-        "name": camera,
-        "src": [
-            "rtsp://test:test@192.168.10.105:554/Preview_06_sub",
-            f"ffmpeg:{camera}#audio=opus",
-        ],
-    }
-    responses.put(
-        url
-        + f"?name={camera}"
-        + f"&src=ffmpeg%253A{camera}%2523audio%253Dopus"
-        + "&src=rtsp%253A%252F%252Ftest%253Atest%2540192.168.10.105%253A554%252F"
-        + "Preview_06_sub",
-        status=200,
+    full_url = str(
+        yarl.URL(url).with_query(
+            {
+                "name": camera,
+                "src": [
+                    "rtsp://test:test@192.168.10.105:554/Preview_06_sub",
+                    f"ffmpeg:{camera}#audio=opus",
+                ],
+            }
+        )
     )
+    responses.put(full_url, status=200)
     await rest_client.streams.add(
         camera,
         [
@@ -103,13 +108,15 @@ async def test_streams_add_list(
         ],
     )
 
-    responses.assert_called_once_with(
-        url, method=METH_PUT, params=params, timeout=ClientTimeout(total=10)
+    responses.assert_called_once_with(full_url, method=METH_PUT)
+    assert_request_timeout(
+        request_timeouts, METH_PUT, url, timeout=ClientTimeout(total=10)
     )
 
 
 async def test_streams_add_str(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     rest_client: Go2RtcRestClient,
 ) -> None:
     """Test add stream."""
@@ -119,20 +126,15 @@ async def test_streams_add_str(
         "name": camera,
         "src": "rtsp://test:test@192.168.10.105:554/Preview_06_sub",
     }
-    responses.put(
-        url
-        + f"?name={camera}"
-        + "&src=rtsp%253A%252F%252Ftest%253Atest%2540192.168.10.105%253A554%252F"
-        + "Preview_06_sub",
-        status=200,
-    )
+    responses.put(str(yarl.URL(url).with_query(params)), status=200)
     await rest_client.streams.add(
         camera,
         "rtsp://test:test@192.168.10.105:554/Preview_06_sub",
     )
 
-    responses.assert_called_once_with(
-        url, method=METH_PUT, params=params, timeout=ClientTimeout(total=10)
+    responses.assert_called_once_with(url, method=METH_PUT, params=params)
+    assert_request_timeout(
+        request_timeouts, METH_PUT, url, timeout=ClientTimeout(total=10)
     )
 
 
@@ -152,7 +154,7 @@ VERSION_ERR = "server version '{}' not >= 1.9.13 and < 2.0.0"
     ],
 )
 async def test_version_supported(
-    responses: aioresponses,
+    responses: aiointercept,
     rest_client: Go2RtcRestClient,
     server_version: str,
     expected_result: AbstractContextManager[Any],
@@ -171,7 +173,7 @@ async def test_version_supported(
 
 
 async def test_webrtc_offer(
-    responses: aioresponses,
+    responses: aiointercept,
     rest_client: Go2RtcRestClient,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -205,7 +207,7 @@ async def test_webrtc_offer(
     ],
 )
 async def test_get_jpeg_snapshot(
-    responses: aioresponses,
+    responses: aiointercept,
     rest_client: Go2RtcRestClient,
     height: int | None,
     width: int | None,
@@ -226,7 +228,7 @@ async def test_get_jpeg_snapshot(
 
 
 async def test_schemes(
-    responses: aioresponses,
+    responses: aiointercept,
     rest_client: Go2RtcRestClient,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -249,7 +251,7 @@ async def test_schemes(
     ],
 )
 async def test_preload_list(
-    responses: aioresponses,
+    responses: aiointercept,
     rest_client: Go2RtcRestClient,
     snapshot: SnapshotAssertion,
     filename: str,
@@ -265,7 +267,8 @@ async def test_preload_list(
 
 
 async def test_preload_enable_no_filters(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     rest_client: Go2RtcRestClient,
 ) -> None:
     """Test enable preload without codec filters."""
@@ -275,8 +278,9 @@ async def test_preload_enable_no_filters(
     responses.put(url + f"?src={camera}", status=200)
     await rest_client.preload.enable(camera)
 
-    responses.assert_called_once_with(
-        url, method=METH_PUT, params=params, timeout=ClientTimeout(total=10)
+    responses.assert_called_once_with(url, method=METH_PUT, params=params)
+    assert_request_timeout(
+        request_timeouts, METH_PUT, url, timeout=ClientTimeout(total=10)
     )
 
 
@@ -331,7 +335,8 @@ async def test_preload_enable_no_filters(
     ],
 )
 async def test_preload_enable_with_filters(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     rest_client: Go2RtcRestClient,
     video_codecs: list[str] | None,
     audio_codecs: list[str] | None,
@@ -351,13 +356,15 @@ async def test_preload_enable_with_filters(
         microphone_codec_filter=microphone_codecs,
     )
 
-    responses.assert_called_once_with(
-        url, method=METH_PUT, params=expected_params, timeout=ClientTimeout(total=10)
+    responses.assert_called_once_with(url, method=METH_PUT, params=expected_params)
+    assert_request_timeout(
+        request_timeouts, METH_PUT, url, timeout=ClientTimeout(total=10)
     )
 
 
 async def test_preload_disable(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     rest_client: Go2RtcRestClient,
 ) -> None:
     """Test disable preload."""
@@ -367,6 +374,7 @@ async def test_preload_disable(
     responses.delete(url + f"?src={camera}", status=200)
     await rest_client.preload.disable(camera)
 
-    responses.assert_called_once_with(
-        url, method="DELETE", params=params, timeout=ClientTimeout(total=10)
+    responses.assert_called_once_with(url, method="DELETE", params=params)
+    assert_request_timeout(
+        request_timeouts, "DELETE", url, timeout=ClientTimeout(total=10)
     )

--- a/uv.lock
+++ b/uv.lock
@@ -101,16 +101,17 @@ wheels = [
 ]
 
 [[package]]
-name = "aioresponses"
-version = "0.7.8"
+name = "aiointercept"
+version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
-    { name = "packaging" },
+    { name = "multidict" },
+    { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/03/532bbc645bdebcf3b6af3b25d46655259d66ce69abba7720b71ebfabbade/aioresponses-0.7.8.tar.gz", hash = "sha256:b861cdfe5dc58f3b8afac7b0a6973d5d7b2cb608dd0f6253d16b8ee8eaf6df11", size = 40253, upload-time = "2025-01-19T18:14:03.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/62/f310cd6002a5e4f9993e7b8cd776f90a44254ab8cf2fc0cb5638317573b9/aiointercept-0.1.9.tar.gz", hash = "sha256:4f1996e0d4dc69024f48a408a4c9749e42821022241bc722203c3c84144d44f2", size = 164044, upload-time = "2026-07-08T19:32:10.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b7/584157e43c98aa89810bc2f7099e7e01c728ecf905a66cf705106009228f/aioresponses-0.7.8-py2.py3-none-any.whl", hash = "sha256:b73bd4400d978855e55004b23a3a84cb0f018183bcf066a85ad392800b5b9a94", size = 12518, upload-time = "2025-01-19T18:13:59.633Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6e/c6d8fe7160f2a97d313d1a86b6d90575d44d4017dbd5065f9843ac88de6d/aiointercept-0.1.9-py3-none-any.whl", hash = "sha256:ef89ea659e3c6aded2140cf4b66dd1ce2ceb4c3ada4f5df27696d613a1fc175c", size = 19486, upload-time = "2026-07-08T19:32:09.148Z" },
 ]
 
 [[package]]
@@ -438,7 +439,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "aioresponses" },
+    { name = "aiointercept" },
     { name = "covdefaults" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -463,7 +464,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aioresponses", specifier = ">=0.7.6" },
+    { name = "aiointercept", specifier = ">=0.1.9" },
     { name = "covdefaults", specifier = ">=2.3.0" },
     { name = "mypy", specifier = "==2.3.0" },
     { name = "pre-commit", specifier = "==4.6.1" },


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

- aioresponses uses aiohttp internal details which makes aioresponses prone to break when aiohttp changes.
- Replace aioresponses with aiointercept. The latter creates a real `aiohttp.web` test server. The API is very similar to aioresponses.
- https://github.com/Polandia94/aiointercept
- This allows us to update to aiohttp 3.14.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
