### PR TITLE
Disable ruff rule max-positional-args for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ warn_unused_ignores = true
     "N802",  # Function name {name} should be lowercase
     "N816",  # Variable {name} in global scope should not be mixedCase
     "PLR0913", # Too many arguments in function definition
+    "PLR0917", # Too many positional arguments
     "S101",  # Use of assert detected
     "SLF001", # Private member accessed: {access}
     "T201",  # print found


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

- This linting is just annoying in tests.
- Example: https://github.com/home-assistant-libs/python-go2rtc-client/actions/runs/30533959314/job/90842620083?pr=358

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
